### PR TITLE
PXT-179 Add a if_exists parameter to create/add APIs

### DIFF
--- a/pixeltable/catalog/column.py
+++ b/pixeltable/catalog/column.py
@@ -172,6 +172,12 @@ class Column:
         assert self.tbl is not None
         return self.tbl.media_validation
 
+    @property
+    def _has_dependent_user_columns(self) -> bool:
+        """ Returns True if this column has dependent user columns"""
+        dependent_user_cols = [c for c in self.dependent_cols if c.name is not None]
+        return len(dependent_user_cols) > 0
+
     def source(self) -> None:
         """
         If this is a computed col and the top-level expr is a function call, print the source, if possible.

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -427,11 +427,75 @@ class Table(SchemaObject):
             raise excs.Error(f'Column name must be a string, got {type(col_name)}')
         if not isinstance(spec, (ts.ColumnType, exprs.Expr, type, _GenericAlias)):
             raise excs.Error(f'Column spec must be a ColumnType, Expr, or type, got {type(spec)}')
-        self.add_column(stored=None, print_stats=False, on_error='abort', **{col_name: spec})
+        self.add_column(stored=None, print_stats=False, on_error='abort', if_exists='error', **{col_name: spec})
+
+    def __column_has_dependents(self, col: Column) -> bool:
+        """Returns True if the column has dependents, False otherwise."""
+        assert col is not None
+        if col._has_dependent_user_columns:
+            return True
+        dependent_stores = [
+            (view, store)
+            for view in [self] + self._get_views(recursive=True)
+            for store in view._tbl_version.external_stores.values()
+            if col in store.get_local_columns()
+        ]
+        if len(dependent_stores) > 0:
+            return True
+        return False
+
+    def __skip_or_drop_existing_columns(self, new_col_spec: dict[str, Any], if_exists: IfExistsParam) -> None:
+        """ Check for existing column and handle them according to the if_exists parameter.
+
+        Note that this function will remove any column names from the passed in `new_col_spec` if `if_exists='ignore'`.
+
+        Args:
+            new_col_spec: A dictionary mapping column names to column specifications.
+            if_exists: Determines the behavior if a column already exists. Must be one of the following:
+                - `'error'`: an exception will be raised.
+                - `'ignore'`: do nothing and return.
+                - `'replace'` or `'replace_force'`: replace the existing column with the new column,
+                if the existing column has no dependents.
+
+        Raises:
+            Error: If any column already exists and `if_exists='error'`,
+                or the existing column has dependents,
+                or the existing column is for a snapshot.
+        """
+        assert not self.get_metadata()['is_snapshot']
+        existing_col_names = set(self._schema.keys())
+        cols_to_ignore = []
+        for new_col_name in new_col_spec.keys():
+            if new_col_name in existing_col_names:
+                if if_exists == IfExistsParam.ERROR:
+                    raise excs.Error(f'Duplicate column name: {new_col_name!r}')
+                elif if_exists == IfExistsParam.IGNORE:
+                    cols_to_ignore.append(new_col_name)
+                elif if_exists == IfExistsParam.REPLACE or if_exists == IfExistsParam.REPLACE_FORCE:
+                    if new_col_name not in self._tbl_version.cols_by_name:
+                        # for views, it is possible that the existing column
+                        # is a base table column; in that case, we should not
+                        # drop/replace that column. Continue to raise error.
+                        raise excs.Error(
+                            f'Column {new_col_name!r} is a base table column. Cannot replace it.'
+                        )
+                    col = self._tbl_version.cols_by_name[new_col_name]
+                    # cannot drop a column with dependents; so reject
+                    # replace directive if column has dependents.
+                    if self.__column_has_dependents(col):
+                        raise excs.Error(
+                            f'Column {new_col_name!r} already exists and has dependents. Cannot {if_exists.value} it.'
+                        )
+                    self.drop_column(new_col_name)
+                    assert new_col_name not in self._tbl_version.cols_by_name
+        for _cname in cols_to_ignore:
+            assert _cname in existing_col_names
+            del new_col_spec[_cname]
 
     def add_columns(
         self,
-        schema: dict[str, Union[ts.ColumnType, builtins.type, _GenericAlias]]
+        schema: dict[str, Union[ts.ColumnType, builtins.type, _GenericAlias]],
+        if_exists: Literal['error', 'ignore', 'replace'] = 'error'
     ) -> UpdateStatus:
         """
         Adds multiple columns to the table. The columns must be concrete (non-computed) columns; to add computed columns,
@@ -442,12 +506,19 @@ class Table(SchemaObject):
 
         Args:
             schema: A dictionary mapping column names to types.
+            if_exists: Determines the behavior if a column already exists. Must be one of the following:
+            - `'error'`: an exception will be raised.
+            - `'ignore'`: do nothing and return.
+            - `'replace'`: drop the existing column and add the new column, iff it has no dependents.
+            Defaults to `'error'`.
+            Note that the if_exists parameter is applied to all columns in the schema.
+            To apply different behaviors to different columns, please use [`add_column()`][pixeltable.Table.add_column] for each column.
 
         Returns:
             Information about the execution status of the operation.
 
         Raises:
-            Error: If any column name is invalid or already exists.
+            Error: If any column name is invalid, or already exists and `if_exists='error'`, or has dependents.
 
         Examples:
             Add multiple columns to the table `my_table`:
@@ -460,13 +531,21 @@ class Table(SchemaObject):
             ... tbl.add_columns(schema)
         """
         self._check_is_dropped()
+        if self.get_metadata()['is_snapshot']:
+            raise excs.Error('Cannot add column to a snapshot.')
         col_schema = {
             col_name: {'type': ts.ColumnType.normalize_type(spec, nullable_default=True, allow_builtin_types=False)}
             for col_name, spec in schema.items()
         }
+        # handle existing columns based on if_exists parameter
+        self.__skip_or_drop_existing_columns(col_schema, IfExistsParam.validated(if_exists, 'if_exists'))
+        # if all columns to be added already exist and user asked to ignore
+        # existing columns, there's nothing to do. Return.
+        if not col_schema:
+            return UpdateStatus()
         new_cols = self._create_columns(col_schema)
         for new_col in new_cols:
-            self._verify_column(new_col, set(self._schema.keys()), set(self._query_names))
+            self._verify_column(new_col, set(self._query_names))
         status = self._tbl_version.add_columns(new_cols, print_stats=False, on_error='abort')
         FileCache.get().emit_eviction_warnings()
         return status
@@ -481,6 +560,7 @@ class Table(SchemaObject):
         stored: Optional[bool] = None,
         print_stats: bool = False,
         on_error: Literal['abort', 'ignore'] = 'abort',
+        if_exists: Literal['error', 'ignore', 'replace'] = 'error',
         **kwargs: Union[ts.ColumnType, builtins.type, _GenericAlias, exprs.Expr]
     ) -> UpdateStatus:
         """
@@ -492,17 +572,21 @@ class Table(SchemaObject):
             print_stats: If `True`, print execution metrics during evaluation.
             on_error: Determines the behavior if an error occurs while evaluating the column expression for at least one
                 row.
-
                 - `'abort'`: an exception will be raised and the column will not be added.
                 - `'ignore'`: execution will continue and the column will be added. Any rows
                   with errors will have a `None` value for the column, with information about the error stored in the
                   corresponding `tbl.col_name.errortype` and `tbl.col_name.errormsg` fields.
+            if_exists: Determines the behavior if the column already exists. Must be one of the following:
+                - `'error'`: an exception will be raised.
+                - `'ignore'`: do nothing and return.
+                - `'replace'`: drop the existing column and add the new column, iff it has no dependents.
+                Defaults to `'error'`.
 
         Returns:
             Information about the execution status of the operation.
 
         Raises:
-            Error: If the column name is invalid or already exists.
+            Error: If the column name is invalid, or already exists and `if_exists='erorr'`, or has depdendents.
 
         Examples:
             Add an int column:
@@ -514,6 +598,8 @@ class Table(SchemaObject):
             >>> tbl['new_col'] = pxt.Int
         """
         self._check_is_dropped()
+        if self.get_metadata()['is_snapshot']:
+            raise excs.Error('Cannot add column to a snapshot.')
         # verify kwargs and construct column schema dict
         if len(kwargs) != 1:
             raise excs.Error(
@@ -532,8 +618,14 @@ class Table(SchemaObject):
         if stored is not None:
             col_schema['stored'] = stored
 
-        new_col = self._create_columns({col_name: col_schema})[0]
-        self._verify_column(new_col, set(self._schema.keys()), set(self._query_names))
+        # handle existing column based on if_exists parameter
+        col_to_add = {col_name: col_schema}
+        self.__skip_or_drop_existing_columns(col_to_add, IfExistsParam.validated(if_exists, 'if_exists'))
+        if not col_to_add:
+            return UpdateStatus()
+
+        new_col = self._create_columns(col_to_add)[0]
+        self._verify_column(new_col, set(self._query_names))
         status = self._tbl_version.add_columns([new_col], print_stats=print_stats, on_error=on_error)
         FileCache.get().emit_eviction_warnings()
         return status
@@ -544,6 +636,7 @@ class Table(SchemaObject):
         stored: Optional[bool] = None,
         print_stats: bool = False,
         on_error: Literal['abort', 'ignore'] = 'abort',
+        if_exists: Literal['error', 'ignore', 'replace'] = 'error',
         **kwargs: exprs.Expr
     ) -> UpdateStatus:
         """
@@ -551,12 +644,25 @@ class Table(SchemaObject):
 
         Args:
             kwargs: Exactly one keyword argument of the form `col_name=expression`.
+            stored: Whether the column is materialized and stored or computed on demand. Only valid for image columns.
+            print_stats: If `True`, print execution metrics during evaluation.
+            on_error: Determines the behavior if an error occurs while evaluating the column expression for at least one
+                row.
+                - `'abort'`: an exception will be raised and the column will not be added.
+                - `'ignore'`: execution will continue and the column will be added. Any rows
+                    with errors will have a `None` value for the column, with information about the error stored in the
+                    corresponding `tbl.col_name.errortype` and `tbl.col_name.errormsg` fields.
+            if_exists: Determines the behavior if the column already exists. Must be one of the following:
+                - `'error'`: an exception will be raised.
+                - `'ignore'`: do nothing and return.
+                - `'replace'`: drop the existing column and add the new column, iff it has no dependents.
+                Defaults to `'error'`.
 
         Returns:
             Information about the execution status of the operation.
 
         Raises:
-            Error: If the column name is invalid or already exists.
+            Error: If the column name is invalid or already exists and `if_exists='error' or has depdendents.
 
         Examples:
             For a table with an image column `frame`, add an image column `rotated` that rotates the image by
@@ -569,6 +675,8 @@ class Table(SchemaObject):
             >>> tbl.add_computed_column(rotated=tbl.frame.rotate(90), stored=False)
         """
         self._check_is_dropped()
+        if self.get_metadata()['is_snapshot']:
+            raise excs.Error('Cannot add column to a snapshot.')
         if len(kwargs) != 1:
             raise excs.Error(
                 f'add_computed_column() requires exactly one keyword argument of the form "column-name=type|value-expression"; '
@@ -582,8 +690,14 @@ class Table(SchemaObject):
         if stored is not None:
             col_schema['stored'] = stored
 
-        new_col = self._create_columns({col_name: col_schema})[0]
-        self._verify_column(new_col, set(self._schema.keys()), set(self._query_names))
+        # handle existing columns based on if_exists parameter
+        col_to_add = {col_name: col_schema}
+        self.__skip_or_drop_existing_columns(col_to_add, IfExistsParam.validated(if_exists, 'if_exists'))
+        if not col_to_add:
+            return UpdateStatus()
+
+        new_col = self._create_columns(col_to_add)[0]
+        self._verify_column(new_col, set(self._query_names))
         status = self._tbl_version.add_columns([new_col], print_stats=print_stats, on_error=on_error)
         FileCache.get().emit_eviction_warnings()
         return status
@@ -664,15 +778,13 @@ class Table(SchemaObject):
 
     @classmethod
     def _verify_column(
-            cls, col: Column, existing_column_names: set[str], existing_query_names: Optional[set[str]] = None
+            cls, col: Column, existing_query_names: Optional[set[str]] = None
     ) -> None:
         """Check integrity of user-supplied Column and supply defaults"""
         if is_system_column_name(col.name):
             raise excs.Error(f'{col.name!r} is a reserved name in Pixeltable; please choose a different column name.')
         if not is_valid_identifier(col.name):
             raise excs.Error(f"Invalid column name: {col.name!r}")
-        if col.name in existing_column_names:
-            raise excs.Error(f'Duplicate column name: {col.name!r}')
         if existing_query_names is not None and col.name in existing_query_names:
             raise excs.Error(f'Column name conflicts with a registered query: {col.name!r}')
         if col.stored is False and not (col.is_computed and col.col_type.is_image_type()):
@@ -687,7 +799,7 @@ class Table(SchemaObject):
         """Check integrity of user-supplied schema and set defaults"""
         column_names: set[str] = set()
         for col in schema:
-            cls._verify_column(col, column_names)
+            cls._verify_column(col)
             column_names.add(col.name)
 
     def __check_column_name_exists(self, column_name: str, include_bases: bool = False) -> None:

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -25,7 +25,7 @@ from ..exprs import ColumnRef
 from ..utils.description_helper import DescriptionHelper
 from ..utils.filecache import FileCache
 from .column import Column
-from .globals import _ROWID_COLUMN_NAME, MediaValidation, UpdateStatus, is_system_column_name, is_valid_identifier
+from .globals import _ROWID_COLUMN_NAME, MediaValidation, UpdateStatus, is_system_column_name, is_valid_identifier, IfExistsParam
 from .schema_object import SchemaObject
 from .table_version import TableVersion
 from .table_version_path import TableVersionPath
@@ -774,10 +774,29 @@ class Table(SchemaObject):
         """
         self._tbl_version.rename_column(old_name, new_name)
 
+    def _list_indexinfo_for_test(self) -> list[dict[str, Any]]:
+        """
+        Returns list of all the indexes on this table. Used for testing.
+
+        Returns:
+            A list of index information, each containing the index's
+            id, name, and the name of the column it indexes.
+        """
+        assert not self._is_dropped
+        index_info = []
+        for idx_name, idx in self._tbl_version.idxs_by_name.items():
+            index_info.append({
+                '_id': idx.id,
+                '_name': idx_name,
+                '_column': idx.col.name
+            })
+        return index_info
+
     def add_embedding_index(
             self, column: Union[str, ColumnRef], *, idx_name: Optional[str] = None,
             string_embed: Optional[pxt.Function] = None, image_embed: Optional[pxt.Function] = None,
-            metric: str = 'cosine'
+            metric: str = 'cosine',
+            if_exists: Literal['error', 'ignore', 'replace', 'replace_force'] = 'error'
     ) -> None:
         """
         Add an embedding index to the table. Once the index is added, it will be automatically kept up to data as new
@@ -796,9 +815,14 @@ class Table(SchemaObject):
             image_embed: A function to embed images; required if the column is an `Image` column.
             metric: Distance metric to use for the index; one of `'cosine'`, `'ip'`, or `'l2'`;
                 the default is `'cosine'`.
+            if_exists: Directive for handling an existing index with the same name. Must be one of the following:
+                - `'error'`: raise an error if an index with the same name already exists.
+                - `'ignore'`: do nothing if an index with the same name already exists.
+                - `'replace'` or `'replace_force'`: replace the existing index with the new one.
+                Defaults to `'error'`.
 
         Raises:
-            Error: If an index with that name already exists for the table, or if the specified column does not exist.
+            Error: If an index with that name already exists for the table and if_exists='error', or if the specified column does not exist.
 
         Examples:
             Add an index to the `img` column of the table `my_table` by column name:
@@ -842,7 +866,18 @@ class Table(SchemaObject):
             col = column.col
 
         if idx_name is not None and idx_name in self._tbl_version.idxs_by_name:
-            raise excs.Error(f'Duplicate index name: {idx_name}')
+            _if_exists = IfExistsParam.validated(if_exists, 'if_exists')
+            # An index with the same name already exists.
+            # Handle it according to if_exists.
+            if _if_exists == IfExistsParam.ERROR:
+                raise excs.Error(f'Duplicate index name: {idx_name}')
+            if not isinstance(self._tbl_version.idxs_by_name[idx_name].idx, index.EmbeddingIndex):
+                raise excs.Error(f'Index `{idx_name}` is not an embedding index. Cannot {_if_exists.value} it.')
+            if _if_exists == IfExistsParam.IGNORE:
+                return
+            assert _if_exists == IfExistsParam.REPLACE or _if_exists == IfExistsParam.REPLACE_FORCE
+            self.drop_index(idx_name=idx_name)
+            assert idx_name not in self._tbl_version.idxs_by_name
         from pixeltable.index import EmbeddingIndex
 
         # create the EmbeddingIndex instance to verify args

--- a/pixeltable/catalog/table.py
+++ b/pixeltable/catalog/table.py
@@ -445,22 +445,18 @@ class Table(SchemaObject):
         return False
 
     def __skip_or_drop_existing_columns(self, new_col_spec: dict[str, Any], if_exists: IfExistsParam) -> None:
-        """ Check for existing column and handle them according to the if_exists parameter.
+        """ Check for existing column in the new column specification and handle them according to the if_exists parameter.
 
         Note that this function will remove any column names from the passed in `new_col_spec` if `if_exists='ignore'`.
 
         Args:
-            new_col_spec: A dictionary mapping column names to column specifications.
-            if_exists: Determines the behavior if a column already exists. Must be one of the following:
-                - `'error'`: an exception will be raised.
-                - `'ignore'`: do nothing and return.
-                - `'replace'` or `'replace_force'`: replace the existing column with the new column,
-                if the existing column has no dependents.
+            new_col_spec: A dictionary mapping the new column names to column specifications.
+            if_exists: Directive for handling an existing column with the same name.
 
         Raises:
             Error: If any column already exists and `if_exists='error'`,
                 or the existing column has dependents,
-                or the existing column is for a snapshot.
+                or the existing column is a basetable column and `if_exists='replace*'`.
         """
         assert not self.get_metadata()['is_snapshot']
         existing_col_names = set(self._schema.keys())
@@ -484,10 +480,11 @@ class Table(SchemaObject):
                     # replace directive if column has dependents.
                     if self.__column_has_dependents(col):
                         raise excs.Error(
-                            f'Column {new_col_name!r} already exists and has dependents. Cannot {if_exists.value} it.'
+                            f'Column {new_col_name!r} already exists and has dependents. Cannot {if_exists.name.lower()} it.'
                         )
                     self.drop_column(new_col_name)
                     assert new_col_name not in self._tbl_version.cols_by_name
+        # remove the existing columns from new_col_spec when if_exists='ignore'
         for _cname in cols_to_ignore:
             assert _cname in existing_col_names
             del new_col_spec[_cname]
@@ -495,7 +492,7 @@ class Table(SchemaObject):
     def add_columns(
         self,
         schema: dict[str, Union[ts.ColumnType, builtins.type, _GenericAlias]],
-        if_exists: Literal['error', 'ignore', 'replace'] = 'error'
+        if_exists: Literal['error', 'ignore', 'replace', 'replace_force'] = 'error'
     ) -> UpdateStatus:
         """
         Adds multiple columns to the table. The columns must be concrete (non-computed) columns; to add computed columns,
@@ -509,7 +506,7 @@ class Table(SchemaObject):
             if_exists: Determines the behavior if a column already exists. Must be one of the following:
             - `'error'`: an exception will be raised.
             - `'ignore'`: do nothing and return.
-            - `'replace'`: drop the existing column and add the new column, iff it has no dependents.
+            - `'replace' or 'replace_force'`: drop the existing column and add the new column, if it has no dependents.
             Defaults to `'error'`.
             Note that the if_exists parameter is applied to all columns in the schema.
             To apply different behaviors to different columns, please use [`add_column()`][pixeltable.Table.add_column] for each column.
@@ -518,7 +515,8 @@ class Table(SchemaObject):
             Information about the execution status of the operation.
 
         Raises:
-            Error: If any column name is invalid, or already exists and `if_exists='error'`, or has dependents.
+            Error: If any column name is invalid, or already exists and `if_exists='error'`,
+                or `if_exists='replace*'` but the column has dependents or is a basetable column.
 
         Examples:
             Add multiple columns to the table `my_table`:
@@ -560,7 +558,7 @@ class Table(SchemaObject):
         stored: Optional[bool] = None,
         print_stats: bool = False,
         on_error: Literal['abort', 'ignore'] = 'abort',
-        if_exists: Literal['error', 'ignore', 'replace'] = 'error',
+        if_exists: Literal['error', 'ignore', 'replace', 'replace_force'] = 'error',
         **kwargs: Union[ts.ColumnType, builtins.type, _GenericAlias, exprs.Expr]
     ) -> UpdateStatus:
         """
@@ -579,14 +577,15 @@ class Table(SchemaObject):
             if_exists: Determines the behavior if the column already exists. Must be one of the following:
                 - `'error'`: an exception will be raised.
                 - `'ignore'`: do nothing and return.
-                - `'replace'`: drop the existing column and add the new column, iff it has no dependents.
+                - `'replace' or 'replace_force'`: drop the existing column and add the new column, if it has no dependents.
                 Defaults to `'error'`.
 
         Returns:
             Information about the execution status of the operation.
 
         Raises:
-            Error: If the column name is invalid, or already exists and `if_exists='erorr'`, or has depdendents.
+            Error: If the column name is invalid, or already exists and `if_exists='erorr'`,
+                or `if_exists='replace*'` but the column has dependents or is a basetable column.
 
         Examples:
             Add an int column:
@@ -655,14 +654,15 @@ class Table(SchemaObject):
             if_exists: Determines the behavior if the column already exists. Must be one of the following:
                 - `'error'`: an exception will be raised.
                 - `'ignore'`: do nothing and return.
-                - `'replace'`: drop the existing column and add the new column, iff it has no dependents.
+                - `'replace' or 'replace_force'`: drop the existing column and add the new column, iff it has no dependents.
                 Defaults to `'error'`.
 
         Returns:
             Information about the execution status of the operation.
 
         Raises:
-            Error: If the column name is invalid or already exists and `if_exists='error' or has depdendents.
+            Error: If the column name is invalid or already exists and `if_exists='error',
+             or `if_exists='replace*'` but the column has dependents or is a basetable column.
 
         Examples:
             For a table with an image column `frame`, add an image column `rotated` that rotates the image by
@@ -886,7 +886,7 @@ class Table(SchemaObject):
         """
         self._tbl_version.rename_column(old_name, new_name)
 
-    def _list_indexinfo_for_test(self) -> list[dict[str, Any]]:
+    def _list_index_info_for_test(self) -> list[dict[str, Any]]:
         """
         Returns list of all the indexes on this table. Used for testing.
 
@@ -984,7 +984,7 @@ class Table(SchemaObject):
             if _if_exists == IfExistsParam.ERROR:
                 raise excs.Error(f'Duplicate index name: {idx_name}')
             if not isinstance(self._tbl_version.idxs_by_name[idx_name].idx, index.EmbeddingIndex):
-                raise excs.Error(f'Index `{idx_name}` is not an embedding index. Cannot {_if_exists.value} it.')
+                raise excs.Error(f'Index `{idx_name}` is not an embedding index. Cannot {_if_exists.name.lower()} it.')
             if _if_exists == IfExistsParam.IGNORE:
                 return
             assert _if_exists == IfExistsParam.REPLACE or _if_exists == IfExistsParam.REPLACE_FORCE

--- a/pixeltable/catalog/table_version.py
+++ b/pixeltable/catalog/table_version.py
@@ -486,11 +486,13 @@ class TableVersion:
         assert idx_md.name in self.idxs_by_name
         idx_info = self.idxs_by_name[idx_md.name]
         del self.idxs_by_name[idx_md.name]
+        del self.idx_md[idx_id]
 
         with Env.get().engine.begin() as conn:
             self._drop_columns([idx_info.val_col, idx_info.undo_col])
             self._update_md(time.time(), conn, preceding_schema_version=preceding_schema_version)
             _logger.info(f'Dropped index {idx_md.name} on table {self.name}')
+
 
     def add_columns(self, cols: Iterable[Column], print_stats: bool, on_error: Literal['abort', 'ignore']) -> UpdateStatus:
         """Adds a column to the table.

--- a/pixeltable/catalog/view.py
+++ b/pixeltable/catalog/view.py
@@ -167,12 +167,12 @@ class View(Table):
 
     @classmethod
     def _verify_column(
-            cls, col: Column, existing_column_names: set[str], existing_query_names: Optional[set[str]] = None
+            cls, col: Column, existing_query_names: Optional[set[str]] = None
     ) -> None:
         # make sure that columns are nullable or have a default
         if not col.col_type.nullable and not col.is_computed:
             raise excs.Error(f'Column {col.name}: non-computed columns in views must be nullable')
-        super()._verify_column(col, existing_column_names, existing_query_names)
+        super()._verify_column(col, existing_query_names)
 
     @classmethod
     def _get_snapshot_path(cls, tbl_version_path: TableVersionPath) -> TableVersionPath:

--- a/pixeltable/globals.py
+++ b/pixeltable/globals.py
@@ -283,6 +283,11 @@ def create_view(
 
     if additional_columns is None:
         additional_columns = {}
+    else:
+        # additional columns should not be in the base table
+        for col_name in additional_columns.keys():
+            if col_name in [c.name for c in tbl_version_path.columns()]:
+                raise excs.Error(f"Column {col_name!r} already exists in the base table.")
     if iterator is None:
         iterator_class, iterator_args = None, None
     else:

--- a/tests/test_component_view.py
+++ b/tests/test_component_view.py
@@ -136,7 +136,7 @@ class TestComponentView:
 
         with pytest.raises(excs.Error) as excinfo:
             view_t.add_column(annotation=pxt.Required[pxt.Json])
-        assert 'must be nullable' in str(excinfo.value)
+        assert "Duplicate column name: 'annotation'" in str(excinfo.value)
 
     def test_update(self, reset_db) -> None:
         # create video table

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -149,6 +149,98 @@ class TestIndex:
             _ = t.order_by(t.split.similarity(sample_img)).limit(1).collect()
         assert "was created without the 'image_embed' parameter" in str(exc_info.value).lower()
 
+    def test_add_embedding_index_if_exists(self, small_img_tbl: pxt.Table, reload_tester: ReloadTester) -> None:
+        skip_test_if_not_installed('transformers')
+        t = small_img_tbl
+        sample_img = t.select(t.img).head(1)[0, 'img']
+        initial_indexes = len(t._list_indexinfo_for_test())
+        t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
+        indexes = t._list_indexinfo_for_test()
+        assert len(indexes) == initial_indexes + 1
+        assert 'clip_idx' == indexes[initial_indexes]['_name']
+        clip_idx_id_before = indexes[initial_indexes]['_id']
+        t.drop_embedding_index(idx_name='clip_idx')
+        t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
+
+        # invalid value for if_exists is rejected, but only when index name is provided.
+        # when index name is not provided, the if_exists parameter is ignored.
+        with pytest.raises(pxt.Error) as exc_info:
+            t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='invalid')
+        assert "if_exists must be one of: ['error', 'ignore', 'replace', 'replace_force']" in str(exc_info.value).lower()
+        indexes = t._list_indexinfo_for_test()
+        assert len(indexes) == initial_indexes + 1
+        assert 'clip_idx' == indexes[initial_indexes]['_name']
+
+        # when index name is not provided, the index is created with
+        # a newly generated name. And if_exists parameter does not apply.
+        # new index is created with a new name.
+        t.add_embedding_index('img', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='error')
+        indexes = t._list_indexinfo_for_test()
+        assert len(indexes) == initial_indexes + 2
+        assert 'clip_idx' == indexes[initial_indexes]['_name']
+
+        # invalid value for if_exists is rejected, but only when the
+        # index name is provided. otherwise, it is never used and is ignored.
+        t.add_embedding_index('img', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='invalid')
+        indexes = t._list_indexinfo_for_test()
+        assert len(indexes) == initial_indexes + 3
+        assert 'clip_idx' == indexes[initial_indexes]['_name']
+        with pytest.raises(pxt.Error) as exc_info:
+            t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='invalid')
+        assert "if_exists must be one of: ['error', 'ignore', 'replace', 'replace_force']" in str(exc_info.value).lower()
+        indexes = t._list_indexinfo_for_test()
+        assert len(indexes) == initial_indexes + 3
+        assert 'clip_idx' == indexes[initial_indexes]['_name']
+
+        # when index name is provided, if_exists parameter is applied.
+        # if_exists='error' raises an error if the index name already exists.
+        # by default, if_exists='error'.
+        with pytest.raises(pxt.Error) as exc_info:
+            t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
+        assert 'duplicate index name' in str(exc_info.value).lower()
+        with pytest.raises(pxt.Error) as exc_info:
+            t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='error')
+        assert 'duplicate index name' in str(exc_info.value).lower()
+        indexes = t._list_indexinfo_for_test()
+        assert len(indexes) == initial_indexes + 3
+        assert 'clip_idx' == indexes[initial_indexes]['_name']
+
+        # if_exists='ignore' does nothing if the index name already exists.
+        t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='ignore')
+        indexes = t._list_indexinfo_for_test()
+        assert len(indexes) == initial_indexes + 3
+        assert 'clip_idx' == indexes[initial_indexes]['_name']
+
+        # cannot use if_exists to ignore or replace an existing index
+        # that is not an embedding (like, default btree indexes).
+        assert 'idx0' == indexes[0]['_name']
+        for _ie in ['ignore', 'replace', 'replace_force']:
+            with pytest.raises(pxt.Error) as exc_info:
+                t.add_embedding_index('img', idx_name='idx0', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists=_ie)
+            assert 'not an embedding index' in str(exc_info.value).lower(), f'for if_exists={_ie}'
+
+        # if_exists='replace' replaces the existing index with the new one.
+        t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='replace')
+        indexes = t._list_indexinfo_for_test()
+        assert len(indexes) == initial_indexes + 3
+        assert 'clip_idx' != indexes[initial_indexes]['_name']
+        assert 'clip_idx' == indexes[initial_indexes+2]['_name']
+        assert clip_idx_id_before != indexes[initial_indexes+2]['_id']
+
+        # sanity check: use the replaced index to run a query.
+        # use the index hint in similary function to ensure clip_idx is used.
+        _ = t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3).collect()
+
+        # sanity check persistence
+        _ = reload_tester.run_query(t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3))
+        # bug: the index hint is not used in the similarity function
+        # when we reload the metadata and run the query. So drop all
+        # other indexes on img column first to ensure clip_idx is used.
+        for idx in indexes:
+            if idx['_name'] != 'clip_idx':
+                t.drop_embedding_index(idx_name=idx['_name'])
+        _ = reload_tester.run_reload_test()
+
     def test_embedding_basic(self, img_tbl: pxt.Table, test_tbl: pxt.Table) -> None:
         skip_test_if_not_installed('transformers')
         img_t = img_tbl

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -153,46 +153,30 @@ class TestIndex:
         skip_test_if_not_installed('transformers')
         t = small_img_tbl
         sample_img = t.select(t.img).head(1)[0, 'img']
-        initial_indexes = len(t._list_indexinfo_for_test())
+        initial_indexes = len(t._list_index_info_for_test())
+
         t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
-        indexes = t._list_indexinfo_for_test()
+        indexes = t._list_index_info_for_test()
         assert len(indexes) == initial_indexes + 1
         assert 'clip_idx' == indexes[initial_indexes]['_name']
         clip_idx_id_before = indexes[initial_indexes]['_id']
-        t.drop_embedding_index(idx_name='clip_idx')
-        t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed)
-
-        # invalid value for if_exists is rejected, but only when index name is provided.
-        # when index name is not provided, the if_exists parameter is ignored.
-        with pytest.raises(pxt.Error) as exc_info:
-            t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='invalid')
-        assert "if_exists must be one of: ['error', 'ignore', 'replace', 'replace_force']" in str(exc_info.value).lower()
-        indexes = t._list_indexinfo_for_test()
-        assert len(indexes) == initial_indexes + 1
-        assert 'clip_idx' == indexes[initial_indexes]['_name']
 
         # when index name is not provided, the index is created with
-        # a newly generated name. And if_exists parameter does not apply.
-        # new index is created with a new name.
+        # a newly generated name. And if_exists parameter does not apply
+        # and will be ignored.
         t.add_embedding_index('img', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='error')
-        indexes = t._list_indexinfo_for_test()
-        assert len(indexes) == initial_indexes + 2
-        assert 'clip_idx' == indexes[initial_indexes]['_name']
+        assert len(t._list_index_info_for_test()) == initial_indexes + 2
 
-        # invalid value for if_exists is rejected, but only when the
-        # index name is provided. otherwise, it is never used and is ignored.
         t.add_embedding_index('img', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='invalid')
-        indexes = t._list_indexinfo_for_test()
-        assert len(indexes) == initial_indexes + 3
-        assert 'clip_idx' == indexes[initial_indexes]['_name']
+        assert len(t._list_index_info_for_test()) == initial_indexes + 3
+
+        # when index name is provided, if_exists parameter is applied.
+        # invalid value is rejected.
         with pytest.raises(pxt.Error) as exc_info:
             t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='invalid')
         assert "if_exists must be one of: ['error', 'ignore', 'replace', 'replace_force']" in str(exc_info.value).lower()
-        indexes = t._list_indexinfo_for_test()
-        assert len(indexes) == initial_indexes + 3
-        assert 'clip_idx' == indexes[initial_indexes]['_name']
+        assert len(t._list_index_info_for_test()) == initial_indexes + 3
 
-        # when index name is provided, if_exists parameter is applied.
         # if_exists='error' raises an error if the index name already exists.
         # by default, if_exists='error'.
         with pytest.raises(pxt.Error) as exc_info:
@@ -201,15 +185,14 @@ class TestIndex:
         with pytest.raises(pxt.Error) as exc_info:
             t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='error')
         assert 'duplicate index name' in str(exc_info.value).lower()
-        indexes = t._list_indexinfo_for_test()
-        assert len(indexes) == initial_indexes + 3
-        assert 'clip_idx' == indexes[initial_indexes]['_name']
+        assert len(t._list_index_info_for_test()) == initial_indexes + 3
 
         # if_exists='ignore' does nothing if the index name already exists.
         t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='ignore')
-        indexes = t._list_indexinfo_for_test()
+        indexes = t._list_index_info_for_test()
         assert len(indexes) == initial_indexes + 3
         assert 'clip_idx' == indexes[initial_indexes]['_name']
+        assert clip_idx_id_before == indexes[initial_indexes]['_id']
 
         # cannot use if_exists to ignore or replace an existing index
         # that is not an embedding (like, default btree indexes).
@@ -218,10 +201,14 @@ class TestIndex:
             with pytest.raises(pxt.Error) as exc_info:
                 t.add_embedding_index('img', idx_name='idx0', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists=_ie)
             assert 'not an embedding index' in str(exc_info.value).lower(), f'for if_exists={_ie}'
+        indexes = t._list_index_info_for_test()
+        assert len(indexes) == initial_indexes + 3
+        assert 'idx0' == indexes[0]['_name']
+        assert 'clip_idx' == indexes[initial_indexes]['_name']
 
         # if_exists='replace' replaces the existing index with the new one.
         t.add_embedding_index('img', idx_name='clip_idx', image_embed=clip_img_embed, string_embed=clip_text_embed, if_exists='replace')
-        indexes = t._list_indexinfo_for_test()
+        indexes = t._list_index_info_for_test()
         assert len(indexes) == initial_indexes + 3
         assert 'clip_idx' != indexes[initial_indexes]['_name']
         assert 'clip_idx' == indexes[initial_indexes+2]['_name']
@@ -234,7 +221,8 @@ class TestIndex:
         # sanity check persistence
         _ = reload_tester.run_query(t.select(t.img.localpath).order_by(t.img.similarity(sample_img, idx='clip_idx'), asc=False).limit(3))
         # bug: the index hint is not used in the similarity function
-        # when we reload the metadata and run the query. So drop all
+        # when we reload the metadata and run the query. PXT-382 tracks
+        # it and a fix pending under PR 411. To workaround, drop all
         # other indexes on img column first to ensure clip_idx is used.
         for idx in indexes:
             if idx['_name'] != 'clip_idx':

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -96,15 +96,9 @@ class TestSnapshot:
         # the time of creating a snapshot will raise an error now.
         tbl = create_test_tbl(name=tbl_path)
         assert 'c1' in tbl.columns and type(tbl.c1.col.col_type) == pxt.StringType
-        orig_val = tbl.select(tbl.c1).collect()[0]['c1']
         with pytest.raises(excs.Error) as exc_info:
             _ = pxt.create_snapshot('snap2', tbl, additional_columns={'c1': pxt.Int})
         assert "Column 'c1' already exists in the base table" in str(exc_info.value)
-        assert 'c1' in tbl.columns and type(tbl.c1.col.col_type) == pxt.StringType
-        s = pxt.create_snapshot('snap2', tbl, additional_columns={'s1': pxt.Int})
-        assert 's1' in s.columns and type(s.s1.col.col_type) == pxt.IntType
-        assert s.select(s.s1).collect()[0] == {'s1': None}
-        assert type(tbl.c1.col.col_type) == pxt.StringType
 
     def __test_create_if_exists(self, sname: str, t: pxt.Table, s: pxt.Table) -> None:
         """ Helper function for testing if_exists parameter while creating a snaphot.

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -6,7 +6,7 @@ import pytest
 import pixeltable as pxt
 import pixeltable.exceptions as excs
 
-from .utils import assert_resultset_eq, clip_img_embed, create_img_tbl, create_test_tbl, reload_catalog, ReloadTester
+from .utils import assert_resultset_eq, clip_img_embed, create_img_tbl, create_test_tbl, reload_catalog, ReloadTester, assert_raises_error
 
 class TestSnapshot:
     def run_basic_test(
@@ -207,15 +207,10 @@ class TestSnapshot:
         assert 'cannot insert into view' in str(excinfo.value).lower()
 
         # adding column is not supported for snapshots
-        with pytest.raises(excs.Error) as exc_info:
-            snap.add_column(non_existing_col1=pxt.String)
-        assert 'cannot add column to a snapshot' in str(exc_info.value).lower()
-        with pytest.raises(excs.Error) as exc_info:
-            snap.add_computed_column(non_existing_col1=tbl.c2 + tbl.c3)
-        assert 'cannot add column to a snapshot' in str(exc_info.value).lower()
-        with pytest.raises(excs.Error) as exc_info:
-            snap.add_columns({'non_existing_col1': pxt.String, 'non_existing_col2': pxt.String})
-        assert 'cannot add column to a snapshot' in str(exc_info.value).lower()
+        expected_msg = 'cannot add column to a snapshot'
+        assert_raises_error(expected_msg, snap.add_column, non_existing_col1=pxt.String)
+        assert_raises_error(expected_msg, snap.add_computed_column, non_existing_col1=tbl.c2 + tbl.c3)
+        assert_raises_error(expected_msg, snap.add_columns, {'non_existing_col1': pxt.String, 'non_existing_col2': pxt.String})
 
         with pytest.raises(pxt.Error) as excinfo:
             _ = snap.delete()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -93,13 +93,17 @@ class TestSnapshot:
                     self.run_basic_test(tbl, query, snap, extra_items=extra_items, reload_md=reload_md)
 
         # adding column with same name as a base table column at
-        # the time of creating a sanpshot is allowed. It overrides
-        # the base table column in the snapshot.
+        # the time of creating a snapshot will raise an error now.
         tbl = create_test_tbl(name=tbl_path)
         assert 'c1' in tbl.columns and type(tbl.c1.col.col_type) == pxt.StringType
-        s = pxt.create_snapshot('snap2', tbl, additional_columns={'c1': pxt.Int})
-        assert 'c1' in s.columns and type(s.c1.col.col_type) == pxt.IntType
-        assert s.select(s.c1).collect()[0] == {'c1': None}
+        orig_val = tbl.select(tbl.c1).collect()[0]['c1']
+        with pytest.raises(excs.Error) as exc_info:
+            _ = pxt.create_snapshot('snap2', tbl, additional_columns={'c1': pxt.Int})
+        assert "Column 'c1' already exists in the base table" in str(exc_info.value)
+        assert 'c1' in tbl.columns and type(tbl.c1.col.col_type) == pxt.StringType
+        s = pxt.create_snapshot('snap2', tbl, additional_columns={'s1': pxt.Int})
+        assert 's1' in s.columns and type(s.s1.col.col_type) == pxt.IntType
+        assert s.select(s.s1).collect()[0] == {'s1': None}
         assert type(tbl.c1.col.col_type) == pxt.StringType
 
     def __test_create_if_exists(self, sname: str, t: pxt.Table, s: pxt.Table) -> None:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -22,7 +22,7 @@ from pixeltable.utils.media_store import MediaStore
 
 from .utils import (assert_resultset_eq, create_table_data, get_audio_files, get_documents, get_image_files,
                     get_video_files, make_tbl, read_data_file, reload_catalog, skip_test_if_not_installed, strip_lines,
-                    validate_update_status, get_multimedia_commons_video_uris, ReloadTester)
+                    validate_update_status, get_multimedia_commons_video_uris, ReloadTester, assert_raises_error, get_raised_error)
 
 
 class TestTable:
@@ -1619,41 +1619,20 @@ class TestTable:
 
         # invalid if_exists is rejected
         expected_err_str = "if_exists must be one of: ['error', 'ignore', 'replace', 'replace_force']"
-        with pytest.raises(excs.Error) as exc_info:
-            t.add_column(non_existing_col1=pxt.Int, if_exists='invalid')
-        assert expected_err_str in str(exc_info.value).lower()
-        with pytest.raises(excs.Error) as exc_info:
-            t.add_computed_column(non_existing_col1=t.c2+t.c3, if_exists='invalid')
-        assert expected_err_str in str(exc_info.value).lower()
-        with pytest.raises(excs.Error) as exc_info:
-            t.add_columns({'non_existing_col1': pxt.Int, 'non_existing_col2': pxt.String}, if_exists='invalid')
-        assert expected_err_str in str(exc_info.value).lower()
-
+        assert_raises_error(expected_err_str, t.add_column, non_existing_col1=pxt.Int, if_exists='invalid')
+        assert_raises_error(expected_err_str, t.add_computed_column, non_existing_col1=t.c2 + t.c3, if_exists='invalid')
+        assert_raises_error(expected_err_str, t.add_columns, {'non_existing_col1': pxt.Int, 'non_existing_col2': pxt.String}, if_exists='invalid')
         assert orig_cnames == t.columns
 
         # if_exists='error' raises an error if the column already exists
         # by default, if_exists='error'
         expected_err_str = "duplicate column name: 'c1'"
-        with pytest.raises(excs.Error) as exc_info:
-            t.add_column(c1=pxt.Int)
-        assert expected_err_str in str(exc_info.value).lower()
-        with pytest.raises(excs.Error) as exc_info:
-            t.add_computed_column(c1=t.c2 + t.c3)
-        assert expected_err_str in str(exc_info.value).lower()
-        with pytest.raises(excs.Error) as exc_info:
-            t.add_columns({'c1': pxt.Int, 'non_existing_col1': pxt.String})
-        assert expected_err_str in str(exc_info.value).lower()
-
-        with pytest.raises(excs.Error) as exc_info:
-            t.add_column(c1=pxt.Int, if_exists='error')
-        assert expected_err_str in str(exc_info.value).lower()
-        with pytest.raises(excs.Error) as exc_info:
-            t.add_computed_column(c1=t.c2 + t.c3, if_exists='error')
-        assert expected_err_str in str(exc_info.value).lower()
-        with pytest.raises(excs.Error) as exc_info:
-            t.add_columns({'c1': pxt.Int, 'non_existing_col1': pxt.String}, if_exists='error')
-        assert expected_err_str in str(exc_info.value).lower()
-
+        assert_raises_error(expected_err_str, t.add_column, c1=pxt.Int)
+        assert_raises_error(expected_err_str, t.add_computed_column, c1=t.c2 + t.c3)
+        assert_raises_error(expected_err_str, t.add_columns, {'c1': pxt.Int, 'non_existing_col1': pxt.String})
+        assert_raises_error(expected_err_str, t.add_column, c1=pxt.Int, if_exists='error')
+        assert_raises_error(expected_err_str, t.add_computed_column, c1=t.c2 + t.c3, if_exists='error')
+        assert_raises_error(expected_err_str, t.add_columns, {'c1': pxt.Int, 'non_existing_col1': pxt.String}, if_exists='error')
         assert orig_cnames == t.columns
         assert type(t.c1.col.col_type) == pxt.StringType
         assert_resultset_eq(t.select(t.c1).order_by(t.c1).collect(), orig_res, True)
@@ -1706,10 +1685,8 @@ class TestTable:
 
         # replace will raise an error if the column has dependents
         t.add_computed_column(non_existing_col3=t.c1+10)
-        with pytest.raises(excs.Error) as exc_info:
-            t.add_column(c1=pxt.String, if_exists='replace')
-        assert ("already exists" in str(exc_info.value).lower()
-            and "has dependents" in str(exc_info.value).lower())
+        error_msg = get_raised_error(t.add_column, c1=pxt.Int, if_exists='replace')
+        assert 'already exists' in error_msg and 'has dependents' in error_msg
         assert 'c1' in t.columns and type(t.c1.col.col_type) == pxt.FloatType
         assert t.select(t.c1).collect()[0] != {'c1': 10}
         assert t.select().order_by(t.c1).collect()[0]['c1'] == t.select().order_by(t.c1).collect()[0]['c2'] + t.select().order_by(t.c1).collect()[0]['c3']

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1607,6 +1607,117 @@ class TestTable:
         t = pxt.get_table(t._name)
         assert len(t.columns) == num_orig_cols
 
+    def test_add_column_if_exists(self, test_tbl: catalog.Table, reload_tester: ReloadTester) -> None:
+        """ Test the if_exists parameter of add_column. """
+        t = test_tbl
+        orig_cnames = t.columns
+        # See create_test_tbl for the column names and types
+        assert 'c1' in orig_cnames and type(t.c1.col.col_type) == pxt.StringType
+        assert 'c2' in orig_cnames and type(t.c2.col.col_type) == pxt.IntType
+        assert 'c3' in orig_cnames and type(t.c3.col.col_type) == pxt.FloatType
+        orig_res = t.select(t.c1).order_by(t.c1).collect()
+
+        # invalid if_exists is rejected
+        expected_err_str = "if_exists must be one of: ['error', 'ignore', 'replace', 'replace_force']"
+        with pytest.raises(excs.Error) as exc_info:
+            t.add_column(non_existing_col1=pxt.Int, if_exists='invalid')
+        assert expected_err_str in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
+            t.add_computed_column(non_existing_col1=t.c2+t.c3, if_exists='invalid')
+        assert expected_err_str in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
+            t.add_columns({'non_existing_col1': pxt.Int, 'non_existing_col2': pxt.String}, if_exists='invalid')
+        assert expected_err_str in str(exc_info.value).lower()
+
+        assert orig_cnames == t.columns
+
+        # if_exists='error' raises an error if the column already exists
+        # by default, if_exists='error'
+        expected_err_str = "duplicate column name: 'c1'"
+        with pytest.raises(excs.Error) as exc_info:
+            t.add_column(c1=pxt.Int)
+        assert expected_err_str in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
+            t.add_computed_column(c1=t.c2 + t.c3)
+        assert expected_err_str in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
+            t.add_columns({'c1': pxt.Int, 'non_existing_col1': pxt.String})
+        assert expected_err_str in str(exc_info.value).lower()
+
+        with pytest.raises(excs.Error) as exc_info:
+            t.add_column(c1=pxt.Int, if_exists='error')
+        assert expected_err_str in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
+            t.add_computed_column(c1=t.c2 + t.c3, if_exists='error')
+        assert expected_err_str in str(exc_info.value).lower()
+        with pytest.raises(excs.Error) as exc_info:
+            t.add_columns({'c1': pxt.Int, 'non_existing_col1': pxt.String}, if_exists='error')
+        assert expected_err_str in str(exc_info.value).lower()
+
+        assert orig_cnames == t.columns
+        assert type(t.c1.col.col_type) == pxt.StringType
+        assert_resultset_eq(t.select(t.c1).order_by(t.c1).collect(), orig_res, True)
+
+        # if_exists='ignore' does nothing if the column already exists
+        t.add_column(c1=pxt.Int, if_exists='ignore')
+        assert orig_cnames == t.columns
+        assert type(t.c1.col.col_type) == pxt.StringType
+        assert_resultset_eq(t.select(t.c1).order_by(t.c1).collect(), orig_res, True)
+
+        t.add_computed_column(c1=t.c2+1, if_exists='ignore')
+        assert orig_cnames == t.columns
+        assert type(t.c1.col.col_type) == pxt.StringType
+        assert_resultset_eq(t.select(t.c1).order_by(t.c1).collect(), orig_res, True)
+
+        t.add_columns({'c1': pxt.Int, 'non_existing_col1': pxt.String}, if_exists='ignore')
+        assert 'c1' in t.columns and type(t.c1.col.col_type) == pxt.StringType
+        assert_resultset_eq(t.select(t.c1).order_by(t.c1).collect(), orig_res, True)
+        assert 'non_existing_col1' in t.columns
+
+        # if_exists='replace' replaces the column if it has no dependents
+        t.add_columns({'c1': pxt.Int, 'non_existing_col2': pxt.String}, if_exists='replace')
+        assert 'c1' in t.columns and type(t.c1.col.col_type) == pxt.IntType
+        assert t.select(t.c1).collect()[0] == {'c1': None}
+        assert 'non_existing_col2' in t.columns
+        before_cnames = t.columns
+
+        t.add_column(c1=10, if_exists='replace')
+        assert set(t.columns) == set(before_cnames)
+        assert 'c1' in t.columns and type(t.c1.col.col_type) == pxt.IntType
+        assert t.select(t.c1).collect()[0] != orig_res[0]
+        assert t.select(t.c1).collect()[0] == {'c1': 10}
+
+        # revert restores the state back wrt the underlying persistence.
+        # so it will revert the add_column operation and drop the column
+        # and not restore the original column it replaced.
+        t.revert()
+        assert 'c1' not in t.columns
+
+        t.add_column(c1=10)
+        assert set(t.columns) == set(before_cnames)
+        assert 'c1' in t.columns and type(t.c1.col.col_type) == pxt.IntType
+        assert t.select(t.c1).collect()[0] == {'c1': 10}
+
+        t.add_computed_column(c1=t.c2 + t.c3, if_exists='replace')
+        assert set(t.columns) == set(before_cnames)
+        assert 'c1' in t.columns and type(t.c1.col.col_type) == pxt.FloatType
+        assert t.select(t.c1).collect()[0] != {'c1': 10}
+        assert t.select().order_by(t.c1).collect()[0]['c1'] == t.select().order_by(t.c1).collect()[0]['c2'] + t.select().order_by(t.c1).collect()[0]['c3']
+
+        # replace will raise an error if the column has dependents
+        t.add_computed_column(non_existing_col3=t.c1+10)
+        with pytest.raises(excs.Error) as exc_info:
+            t.add_column(c1=pxt.String, if_exists='replace')
+        assert ("already exists" in str(exc_info.value).lower()
+            and "has dependents" in str(exc_info.value).lower())
+        assert 'c1' in t.columns and type(t.c1.col.col_type) == pxt.FloatType
+        assert t.select(t.c1).collect()[0] != {'c1': 10}
+        assert t.select().order_by(t.c1).collect()[0]['c1'] == t.select().order_by(t.c1).collect()[0]['c2'] + t.select().order_by(t.c1).collect()[0]['c3']
+
+        _ = reload_tester.run_query(t.select(t.c1))
+
+        reload_tester.run_reload_test()
+
     def test_add_column_setitem(self, test_tbl: catalog.Table) -> None:
         t = test_tbl
         num_orig_cols = len(t.columns)

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -218,41 +218,19 @@ class TestView:
         with pytest.raises(excs.Error) as exc_info:
             pxt.create_view('test_view', t, additional_columns={'c1': pxt.Int})
         assert "column 'c1' already exists in the base table" in str(exc_info.value).lower()
-        # a new column specific to view can be added during creation
-        v = pxt.create_view('test_view', t, additional_columns={'v1': pxt.Int})
-        assert 'v1' in v.columns and type(v.v1.col.col_type) == pxt.IntType
-        assert v.select(v.v1).collect()[0]['v1'] == None
 
-        # adding a column with default value to the view
+        # create a view and add a column with default value
+        v = pxt.create_view('test_view', t, additional_columns={'v1': pxt.Int})
         v.add_column(vcol='xxx')
         assert 'vcol' in v.columns and type(v.vcol.col.col_type) == pxt.StringType
-        assert 'vcol' not in t.columns
         assert v.select(v.vcol).collect()[0]['vcol'] == 'xxx'
 
-        # adding a computed column to the view
-        v.add_computed_column(v2=t.c2 + t.c3)
-        assert 'v2' in v.columns and type(v.v2.col.col_type) == pxt.FloatType
-        assert 'v2' not in t.columns
-        assert v.select().collect()[0]['v2'] == v.select().collect()[0]['c2'] + v.select().collect()[0]['c3']
-
-        # adding multiple columns to the view
-        v.add_columns({'v3': pxt.Int, 'v4': pxt.String})
-        assert 'v3' in v.columns and type(v.v3.col.col_type) == pxt.IntType
-        assert 'v4' in v.columns and type(v.v4.col.col_type) == pxt.StringType
-        assert 'v3' not in t.columns
-        assert 'v4' not in t.columns
-        assert v.select(v.v3).collect()[0]['v3'] == None
-        assert v.select(v.v4).collect()[0]['v4'] == None
-
-        _ = reload_tester.run_query(v.select())
-        reload_tester.run_reload_test()
-
-        # adding column with same name as an existing column using the
-        # add_column* APIs on a view will depend on the if_exists parameter.
-        # the existing column may be specific to the view, or a base table column.
+        # add column with same name as an existing column.
+        # the result will depend on the if_exists parameter.
+        # test with the existing column specific to the view, or a base table column.
         # RESOLVE: could not consolidate the following two methods into one
-        # since I could not figure how to pass the schema to the add_column call
-        # with a string variable (also).
+        # since I could not figure how to pass the schema and column refs to the
+        # different APIs.
         self.__test_add_existing_view_column(v, t, 'xxx', pxt.StringType)
         _ = reload_tester.run_query(v.select())
         reload_tester.run_reload_test()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -529,6 +529,17 @@ def assert_img_eq(img1: PIL.Image.Image, img2: PIL.Image.Image) -> None:
     diff = PIL.ImageChops.difference(img1, img2)
     assert diff.getbbox() is None
 
+def assert_raises_error(expected_message, func, *args, **kwargs):
+    """ Assert that the function raises an excs.Error with the expected message """
+    with pytest.raises(excs.Error) as exc_info:
+        func(*args, **kwargs)
+    assert expected_message in str(exc_info.value).lower()
+
+def get_raised_error(func, *args, **kwargs):
+    """ Assert that the function raises an excs.Error and return the error message """
+    with pytest.raises(excs.Error) as exc_info:
+        func(*args, **kwargs)
+    return str(exc_info.value).lower()
 
 def reload_catalog() -> None:
     catalog.Catalog.clear()


### PR DESCRIPTION
This commit adds a new parameter - if_exists - for the add_embedding_index API which can be used to handle scenarios where a named index may already exist. It can direct the API to not add the index and return, or raise it as an error, or replace the existing index with a new one.

Also fixed a bug in drop_index where we were not removing the index entry from the index metadata.

Testing: improved existing testcases and added new testcases for the new parameters and the bug repro.